### PR TITLE
Adding an optional config key to set n_jobs in coadd_nwgint

### DIFF
--- a/eastlake/steps/coadd_nwgint.py
+++ b/eastlake/steps/coadd_nwgint.py
@@ -141,12 +141,7 @@ class CoaddNwgintRunner(Step):
             jobs.append(joblib.delayed(run_and_check)(cmd, "CoaddNwgint", verbose=verbose))
 
         if len(jobs) > 0:
-            if "n_jobs" in self.config.keys():
-                n_jobs = self.config["n_jobs"]
-            else:
-                n_jobs = -1
-
-
+            n_jobs = self.config.get("n_jobs", -1)
             if self.logger is not None:
                 self.logger.warning(
                     "making null weight images for tile %s band %s",

--- a/eastlake/steps/coadd_nwgint.py
+++ b/eastlake/steps/coadd_nwgint.py
@@ -141,6 +141,12 @@ class CoaddNwgintRunner(Step):
             jobs.append(joblib.delayed(run_and_check)(cmd, "CoaddNwgint", verbose=verbose))
 
         if len(jobs) > 0:
+            if "n_jobs" in self.config.keys():
+                n_jobs = self.config["n_jobs"]
+            else:
+                n_jobs = -1
+
+
             if self.logger is not None:
                 self.logger.warning(
                     "making null weight images for tile %s band %s",
@@ -153,5 +159,5 @@ class CoaddNwgintRunner(Step):
                     )
                 )
 
-            with joblib.Parallel(n_jobs=-1, backend="multiprocessing", verbose=100) as par:
+            with joblib.Parallel(n_jobs=n_jobs, backend="multiprocessing", verbose=100) as par:
                 par(jobs)


### PR DESCRIPTION
Adding in an optional config key that sets the n_jobs argument for the coadd_nwgint step, if no key present, reset to default -1. 