### PR TITLE
Swarp patch

### DIFF
--- a/eastlake/steps/delete_sources.py
+++ b/eastlake/steps/delete_sources.py
@@ -72,6 +72,16 @@ class DeleteSources(Step):
                     self.logger.debug("removing file %s" % bkg_rms_file)
                     safe_rm(bkg_rms_file)
 
+                # ...and coadd object map
+                coadd_object_map_file = stash.get_filepaths(
+                    "coadd_object_map", tilename, band=band,
+                    keyerror=False,
+                )
+                if (coadd_object_map_file is not None):
+                    if os.path.isfile(coadd_object_map_file):
+                        self.logger.debug("removing file %s" % coadd_object_map_file)
+                        safe_rm(coadd_object_map_file)
+
             self.logger.error("deleting se images for tile %s" % tilename)
             for band in stash["bands"]:
                 img_files = stash.get_filepaths(

--- a/eastlake/steps/delete_sources.py
+++ b/eastlake/steps/delete_sources.py
@@ -85,7 +85,6 @@ class DeleteSources(Step):
                         safe_rm(coadd_object_map_file)
 
             self.logger.error("deleting swarp files %s" % tilename)
-            coadd_bands = []
             for band in stash["bands"]:
                 # Clean up any single-band files leftover from swarp
                 orig_coadd_path = stash.get_input_pizza_cutter_yaml(tilename, band)["image_path"]
@@ -144,9 +143,9 @@ class DeleteSources(Step):
                         or weight_file_re.fullmatch(coadd_file)
                         or mask_tmp_file_re.fullmatch(coadd_file)
                         or mask_file_re.fullmatch(coadd_file)
-                     ):
-                         coadd_file_path = os.path.join(coadd_dir, coadd_file)
-                         safe_rm(coadd_file_path)
+                    ):
+                        coadd_file_path = os.path.join(coadd_dir, coadd_file)
+                        safe_rm(coadd_file_path)
 
             self.logger.error("deleting se images for tile %s" % tilename)
             for band in stash["bands"]:

--- a/eastlake/steps/delete_sources.py
+++ b/eastlake/steps/delete_sources.py
@@ -123,20 +123,34 @@ class DeleteSources(Step):
                                             self.logger.debug("removing file %s" % t)
                                             safe_rm(t)
 
-            self.logger.error("removing psf links for %s" % tilename)
+                self.logger.error("deleting %s-band nullwt links for %s" % (band, tilename))
 
-            psf_link = os.path.join(
-                base_dir, stash["desrun"], tilename, "psfs",
-                os.path.basename(pyml["psf_path"])
-            )
-            safe_rm(psf_link)
+                for sri in pyml["src_info"]:
+                    nullwt_link = os.path.join(
+                        base_dir, stash["desrun"], tilename, f"nullwt-{band}",
+                        os.path.basename(sri["coadd_nwgint_path"])
+                    )
+                    safe_rm(nullwt_link)
 
-            for sri in pyml["src_info"]:
+                nullwt_path = os.path.join(
+                    base_dir, stash["desrun"], tilename, f"nullwt-{band}",
+                )
+                safe_rmdir(nullwt_path)
+
+                self.logger.error("deleting %s-band psfs links for %s" % (band, tilename))
+
                 psf_link = os.path.join(
                     base_dir, stash["desrun"], tilename, "psfs",
-                    os.path.basename(sri["psf_path"])
+                    os.path.basename(pyml["psf_path"])
                 )
                 safe_rm(psf_link)
+
+                for sri in pyml["src_info"]:
+                    psf_link = os.path.join(
+                        base_dir, stash["desrun"], tilename, "psfs",
+                        os.path.basename(sri["psf_path"])
+                    )
+                    safe_rm(psf_link)
 
             psf_path = os.path.join(
                 base_dir, stash["desrun"], tilename, "psfs",

--- a/eastlake/steps/delete_sources.py
+++ b/eastlake/steps/delete_sources.py
@@ -128,25 +128,25 @@ class DeleteSources(Step):
             # coadds may be made with a different subset of bands
             coadd_dir = os.path.join(
                 base_dir, stash["desrun"], tilename, "coadd")
+            if os.path.isdir(coadd_dir):
+                bands = "".join(stash["bands"])
 
-            bands = "".join(stash["bands"])
+                det_coadd_file_re = re.compile(f"{tilename}_coadd_det_[{bands}]+.fits")
+                coadd_file_re = re.compile(f"{tilename}_coadd_[{bands}]+.fits")
+                weight_file_re = re.compile(f"{tilename}_coadd_weight_[{bands}]+.fits")
+                mask_tmp_file_re = re.compile(f"{tilename}_coadd_[{bands}]+_tmp.fits")
+                mask_file_re = re.compile(f"{tilename}_coadd_[{bands}]+_msk.fits")
 
-            det_coadd_file_re = re.compile(f"{tilename}_coadd_det_[{bands}]+.fits")
-            coadd_file_re = re.compile(f"{tilename}_coadd_[{bands}]+.fits")
-            weight_file_re = re.compile(f"{tilename}_coadd_weight_[{bands}]+.fits")
-            mask_tmp_file_re = re.compile(f"{tilename}_coadd_[{bands}]+_tmp.fits")
-            mask_file_re = re.compile(f"{tilename}_coadd_[{bands}]+_msk.fits")
-
-            for coadd_file in os.listdir(coadd_dir):
-                if (
-                    det_coadd_file_re.fullmatch(coadd_file)
-                    or coadd_file_re.fullmatch(coadd_file)
-                    or weight_file_re.fullmatch(coadd_file)
-                    or mask_tmp_file_re.fullmatch(coadd_file)
-                    or mask_file_re.fullmatch(coadd_file)
-                 ):
-                     coadd_file_path = os.path.join(coadd_dir, coadd_file)
-                     safe_rm(coadd_file_path)
+                for coadd_file in os.listdir(coadd_dir):
+                    if (
+                        det_coadd_file_re.fullmatch(coadd_file)
+                        or coadd_file_re.fullmatch(coadd_file)
+                        or weight_file_re.fullmatch(coadd_file)
+                        or mask_tmp_file_re.fullmatch(coadd_file)
+                        or mask_file_re.fullmatch(coadd_file)
+                     ):
+                         coadd_file_path = os.path.join(coadd_dir, coadd_file)
+                         safe_rm(coadd_file_path)
 
             self.logger.error("deleting se images for tile %s" % tilename)
             for band in stash["bands"]:
@@ -236,10 +236,11 @@ class DeleteSources(Step):
             self.logger.error("deleting empty dirs")
 
             tile_path = os.path.join(base_dir, stash["desrun"], tilename)
-            for root, dirs, files in os.walk(tile_path, topdown=False):
-                for name in dirs:
-                    full_dir = os.path.join(root, name)
-                    if len(os.listdir(full_dir)) == 0:
-                        safe_rmdir(full_dir)
+            if os.path.isdir(tile_path):
+                for root, dirs, files in os.walk(tile_path, topdown=False):
+                    for name in dirs:
+                        full_dir = os.path.join(root, name)
+                        if len(os.listdir(full_dir)) == 0:
+                            safe_rmdir(full_dir)
 
         return 0, stash

--- a/eastlake/steps/swarp.py
+++ b/eastlake/steps/swarp.py
@@ -104,9 +104,10 @@ class SWarpRunner(Step):
 
             self._det_coadd(tilename, stash, band_coadd_data)
 
-            for band, fns in band_coadd_data.items():
-                for fn in fns.values():
-                    safe_rm(fn)
+            if self.config.get("debug", False) is False:
+                for band, fns in band_coadd_data.items():
+                    for fn in fns.values():
+                        safe_rm(fn)
 
             self.logger.error(
                 "%s complete for tile %s" % (self.name, tilename))
@@ -231,9 +232,10 @@ class SWarpRunner(Step):
         output_coadd_mask_file = os.path.join(
             output_coadd_dir, "%s_%s_msk.fits" % (tilename, band))
 
-        safe_rm(output_coadd_sci_file)
-        safe_rm(output_coadd_weight_file)
-        safe_rm(output_coadd_mask_file)
+        if self.config.get("debug", False) is False:
+            safe_rm(output_coadd_sci_file)
+            safe_rm(output_coadd_weight_file)
+            safe_rm(output_coadd_mask_file)
 
         # make the output directory and then move here to run swarp
         # this prevents the intermediate files being fucked up by
@@ -330,7 +332,8 @@ class SWarpRunner(Step):
                 "running swarp for tile %s, band %s w/ mask:\n\t%s" % (
                     tilename, band, " ".join(mask_cmd)))
             run_and_check(mask_cmd, "Mask SWarp", logger=self.logger)
-            safe_rm(dummy_mask_coadd)
+            if self.config.get("debug", False) is False:
+                safe_rm(dummy_mask_coadd)
 
             # now run coadd_assemble
             safe_rm(output_coadd_path)
@@ -376,6 +379,13 @@ class SWarpRunner(Step):
                 "fpack SWarp",
                 logger=self.logger
             )
+
+            # Remove tmp swarp convenience files
+            if self.config.get("debug", False) is False:
+                safe_rm(im_file_list)
+                safe_rm(wgt_file_list)
+                safe_rm(wgt_me_file_list)
+                safe_rm(msk_file_list)
 
         with stash.update_output_pizza_cutter_yaml(tilename, band) as pyml:
             pyml["image_path"] = output_coadd_path + ".fz"
@@ -565,9 +575,10 @@ class SWarpRunner(Step):
             run_and_check(asmb_cmd, "coadd_assemble", logger=self.logger)
 
             # remove tmp files
-            safe_rm(mask_tmp_file)
-            safe_rm(coadd_file)
-            safe_rm(weight_file)
-            safe_rm(mask_file)
+            if self.config.get("debug", False) is False:
+                safe_rm(mask_tmp_file)
+                safe_rm(coadd_file)
+                safe_rm(weight_file)
+                safe_rm(mask_file)
 
         stash.set_filepaths("det_coadd_file", det_coadd_file, tilename)


### PR DESCRIPTION
- Make option to save/remove temporary files from the `swarp` step with `swarp.debug` in the config (note: will only check if the value is present and not False)
- add deletions of all temporary swarp files to the `delete_sources` step

Note: this branch has been rebased to delete_sources-patch, so best if merged after #66 